### PR TITLE
fix: patch 6 security alerts (high + medium + low)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 langgraph>=1.0.10
 langchain>=0.3.0
 langchain-core>=1.2.22
-langchain-openai>=0.2.0
+langchain-openai>=1.1.14
 langchain-anthropic>=0.3.0
 langchain-sandbox>=0.0.6
 langgraph_bigtool>=0.0.3
@@ -15,6 +15,10 @@ langgraph-checkpoint>=4.0.0
 aiohttp>=3.13.4
 anthropic>=0.87.0
 Pygments>=2.20.0
+pillow>=12.2.0
+nbconvert>=7.17.1
+langchain-text-splitters>=1.1.2
+langsmith>=0.7.31
 
 # Data validation and type checking
 pydantic>=2.0.0


### PR DESCRIPTION
## Security Alert Patch

Resolves all 6 open Dependabot security alerts in `context_engineering` (1 high, 4 medium, 1 low). Per user request, this PR covers all severities in a single batch (skill default would patch the highest tier only).

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| pillow | (transitive, unpinned) | `>=12.2.0` | A (transitive floor) | runtime | CVE-2026-40192 (high) |
| nbconvert | (transitive, unpinned) | `>=7.17.1` | A (transitive floor) | runtime | CVE-2026-39377, CVE-2026-39378 (medium) |
| langchain-text-splitters | (transitive, unpinned) | `>=1.1.2` | A (transitive floor) | runtime | CVE-2026-41481 (medium) |
| langsmith | (transitive, unpinned) | `>=0.7.31` | A (transitive floor) | runtime | CVE-2026-41182 (medium) |
| langchain-openai | `>=0.2.0` | `>=1.1.14` | A (raise floor) | runtime | CVE-2026-41488 (low) |

Strategy A = direct manifest edit. Scope = runtime (notebook tutorial repo, no dev/runtime split).

### Major-Version Assessments

Three bumps cross a major boundary; all assessed clean against this repo:

- **pillow 10.x → 12.x**: requires Python ≥3.10; repo already needs 3.10+ via `langgraph>=1.0.10`. Pillow used only transitively (no direct imports in tutorial code).
- **nbconvert 6.x → 7.x**: requires Python ≥3.9; transitive via `jupyter`.
- **langchain-text-splitters 0.x → 1.x** and **langchain-openai 0.x → 1.x**: aligns with the langchain 1.x stack already pinned (`langchain-core>=1.2.22`, `langgraph>=1.0.10`).

### Pre-Existing Resolution Conflict (NOT introduced by this PR)

`pip install -r requirements.txt` currently fails to resolve on `main` because `langchain-sandbox==0.0.6` (latest available) caps `langchain-core<0.4.0`, while the file pins `langchain-core>=1.2.22`. This conflict pre-exists; this PR does not touch either package and reproduces the same failure on unmodified `main`. Worth a follow-up to either drop `langchain-sandbox` or wait for an upstream release that supports langchain-core 1.x.

### CVE Details

- **CVE-2026-40192 / GHSA-whj4-6x5x-4v2j** (high) — pillow: FITS GZIP decompression bomb. https://github.com/advisories/GHSA-whj4-6x5x-4v2j
- **CVE-2026-39377 / GHSA-4c99-qj7h-p3vg** (medium) — nbconvert: Arbitrary file write via path traversal in cell attachment filenames. https://github.com/advisories/GHSA-4c99-qj7h-p3vg
- **CVE-2026-39378 / GHSA-7jqv-fw35-gmx9** (medium) — nbconvert: Arbitrary file read via path traversal in HTMLExporter image embedding. https://github.com/advisories/GHSA-7jqv-fw35-gmx9
- **CVE-2026-41481 / GHSA-fv5p-p927-qmxr** (medium) — langchain-text-splitters: SSRF redirect bypass in `HTMLHeaderTextSplitter.split_text_from_url`. https://github.com/advisories/GHSA-fv5p-p927-qmxr
- **CVE-2026-41182 / GHSA-rr7j-v2q5-chgv** (medium) — langsmith: Streaming token events bypass output redaction. https://github.com/advisories/GHSA-rr7j-v2q5-chgv
- **CVE-2026-41488 / GHSA-r7w7-9xr2-qq2r** (low) — langchain-openai: Image token counting SSRF protection bypass via DNS rebinding. https://github.com/advisories/GHSA-r7w7-9xr2-qq2r

### Linear Tickets

No matching Linear tickets found for any of the 6 CVEs/GHSAs.

### Verification

- [x] requirements.txt edits validated (only version floors changed)
- [ ] Linters: N/A (no lint config in repo)
- [ ] Tests: N/A (no test infrastructure in repo)
- [ ] Pip resolution: blocked by pre-existing `langchain-sandbox` / `langchain-core` conflict on `main` (not introduced by this PR)

🤖 Submitted by langster-patch